### PR TITLE
Load bone names and use animation filenames for animation names

### DIFF
--- a/Noesis/fmt_g1m.py
+++ b/Noesis/fmt_g1m.py
@@ -399,10 +399,8 @@ def parseG1MOid(bs):
 		length = bs.readByte()
 		if (length == 255 or length == -1):
 			break
-		print(length)
 		string = noeStrFromBytes(bs.readBytes(length))
 		stringList.append(string)
-	# return stringList
 
 	for n, b in zip(stringList, boneList):
 		b.name = n

--- a/Noesis/fmt_g1m.py
+++ b/Noesis/fmt_g1m.py
@@ -802,7 +802,7 @@ def function2(v):
 	q[3] = c
 	return q
 
-def processG2A(bs, animCount):
+def processG2A(bs, animCount, animName):
 	keyFramedBoneList = []
 	magic = noeStrFromBytes(bs.readBytes(4))
 	version = noeStrFromBytes(bs.readBytes(4))
@@ -873,7 +873,7 @@ def processG2A(bs, animCount):
 		else:
 			print("G2A Animation not compatible with the skeleton")
 			return -1
-	anim = NoeKeyFramedAnim("G2A Animation " + str(animCount), boneList, keyFramedBoneList, framerate)
+	anim = NoeKeyFramedAnim(animName, boneList, keyFramedBoneList, framerate)
 	animationList.append(anim)
 	print("G2A Animation " + str(animCount + 1) + " loaded")
 	return framerate
@@ -907,7 +907,7 @@ def function3(chanValues, chanTimes, indexr, componentCount):
 			allvalues[u].append(value)
 	return [allvalues, alltimes]
 
-def processG1A(bs, animCount):
+def processG1A(bs, animCount, animName):
 	keyFramedBoneList = []
 	magic = noeStrFromBytes(bs.readBytes(4))
 	version = noeStrFromBytes(bs.readBytes(4))
@@ -1005,7 +1005,7 @@ def processG1A(bs, animCount):
 		else:
 			print("G1A Animation not compatible with the skeleton")
 			return -1
-	anim = NoeKeyFramedAnim("G1A Animation " + str(animCount), boneList, keyFramedBoneList, 30)
+	anim = NoeKeyFramedAnim(animName, boneList, keyFramedBoneList, 30)
 	animationList.append(anim)
 	print("G1A Animation " + str(animCount + 1) + " loaded")
 	return 30
@@ -1202,6 +1202,7 @@ def LoadModel(data, mdlList):
 
 		for animPath in animPaths:
 			with open(animPath, "rb") as gaStream:
+				animName = os.path.basename(animPath)[:-4] # Filename without extension
 				gaData = gaStream.read()
 				gaBs = NoeBitStream(gaData)
 				gaBs.setEndian(endian)
@@ -1209,9 +1210,9 @@ def LoadModel(data, mdlList):
 				gaBs.seek(0)
 				tempFrame = -1
 				if magic == 0x4732415F:
-					tempframe = processG2A(gaBs, animCount)
+					tempframe = processG2A(gaBs, animCount, animName)
 				elif magic == 0x4731415F:
-					tempframe = processG1A(gaBs, animCount)
+					tempframe = processG1A(gaBs, animCount, animName)
 				if tempframe != -1:
 					globalFramerate = tempframe
 					animCount += 1

--- a/Noesis/fmt_g1m.py
+++ b/Noesis/fmt_g1m.py
@@ -733,7 +733,7 @@ def processG1T(bs):
 			textureData = bs.readBytes(offsetList[i + 1] - offsetList[i] - headerSize)
 		else:
 			textureData = bs.readBytes(bs.dataSize - offsetList[i] - headerSize - tableoffset)
-		if texSys == 0 and mortonWidth > 0: print("MipSys is %d, but morton width is defined as %d-- Morton maybe not necessary!" % (txtSys, mortonWidth))
+		if texSys == 0 and mortonWidth > 0: print("MipSys is %d, but morton width is defined as %d-- Morton maybe not necessary!" % (texSys, mortonWidth))
 		print("texture %d/%d %dx%d (%X, %X)" % (i + 1, textureCount, width, height, textureFormat, len(textureData)))
 		if mortonWidth > 0:
 			textureData = rapi.imageFromMortonOrder(textureData, width >> 1, height >> 2, mortonWidth)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Enable choosing a g1t texture file. Choosing a wrong one will lead to errors. On
 
 Enable choosing another g1m which contains the skeleton. Choosing a wrong one or not choosing one for a model needing one will lead to errors.
 
+* bLoadG1MOid
+
+Enable choosing an `Oid.bin` file which contains the bone names for the skeleton.
+
 * bAutoLoadG1MS
 
 Load the first g1m in the same folder as a skeleton. Put it to False when using model merging.


### PR DESCRIPTION
This pull request adds a few things.
Gust games (at least) store bone names with the models in an `Oid.bin` file next to the model, so this adds functionality to load and apply them.
Changes the animation loading function to use the animation filename instead of "GXA Animation X" for the animation name. 
Fixes a typo in the texture loading function so Vita files load. 